### PR TITLE
Typo in numbered list

### DIFF
--- a/worksheet.md
+++ b/worksheet.md
@@ -396,7 +396,7 @@ Given that the Sense HAT is capable of reporting its exact orientation and has a
 		return x,y
 	```
 
-1, The full code should now look like this:
+1. The full code should now look like this:
 
 	```python
 	from sense_hat import SenseHat


### PR DESCRIPTION
Correct markdown in numbered list. Also fixes the markdown for the formatting of the python code in that part of the list. 